### PR TITLE
Fix macOS build and Linux icon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.22)
 
-include(cmake/UniversalAppleBuild.cmake)
+include(cmake/AppleBuild.cmake)
 
 project(
   BasicGuiProjectSetupOpenGL

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -25,7 +25,8 @@
       "generator": "Xcode",
       "binaryDir": "build/xcode-debug",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug"
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_OSX_ARCHITECTURES": "x86_64;arm64"
       },
       "condition": {
         "type": "equals",
@@ -39,7 +40,8 @@
       "generator": "Xcode",
       "binaryDir": "build/xcode-release",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release"
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_OSX_ARCHITECTURES": "x86_64;arm64"
       },
       "condition": {
         "type": "equals",

--- a/cmake/AppleBuild.cmake
+++ b/cmake/AppleBuild.cmake
@@ -1,7 +1,8 @@
 # This file needs to be included before calling `project`.
 if (APPLE AND "${CMAKE_GENERATOR}" STREQUAL "Xcode")
-  # Generate universal executable for Apple hardware.
-  set(CMAKE_OSX_ARCHITECTURES "$(ARCHS_STANDARD)")
+  # Define apple architecture for Release builds, use default. For an explicit
+  # universal executable use `x86_64;arm64`.
+  set(CMAKE_OSX_ARCHITECTURES "$(ARCHS_STANDARD)" CACHE INTERNAL "OS X architecture")
 
   # Support older macOS versions.
   set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15 CACHE STRING "Minimum OS X deployment version")

--- a/docs/BuildAndExecution.md
+++ b/docs/BuildAndExecution.md
@@ -89,7 +89,8 @@ Run on a built target, in this example **debug**:
 ```
 
 Though, even better is to use **Xcode as generator** to create app builds on macOS. Only difference in usage is running
-CMake with `-GXcode`. If `CMAKE_OSX_ARCHITECTURES` is not set, it will create universal binaries on M1/2 macs.
+CMake with `-GXcode` and setting the `CMAKE_OSX_ARCHITECTURES` variable, for example to `x86_64;arm64` for a universal
+binaries.
 
 To run a **debug** build created with Xcode:
 

--- a/docs/CMakePresets.md
+++ b/docs/CMakePresets.md
@@ -67,6 +67,9 @@ cpack --preset release
 
 ## Workflows
 
+> [!IMPORTANT]
+> Workflow presets are only available in CMake version 3.25 and up.
+
 To list all available workflows, some dependent on the current system:
 
 ```shell

--- a/docs/Packaging.md
+++ b/docs/Packaging.md
@@ -23,8 +23,8 @@ Packaging settings for the application executable are in `src/app/cmake/packagin
 The final application build for Apple devices should be built via the `Xcode` generator with CMake.
 
 ```shell
-cmake -GXcode -DCMAKE_BUILD_TYPE=Release -B build/xcode
-cmake --build build/xcode
+cmake -GXcode -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -B build/xcode
+cmake --build build/xcode --config Release
 ```
 
 ### Windows
@@ -61,8 +61,8 @@ system**.
 Xcode should be used to create the release build for the application distributable.
 
 ```shell
-cmake -GXcode -DCMAKE_BUILD_TYPE=Release -B build/xcode
-cmake --build build/xcode
+cmake -GXcode -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -B build/xcode
+cmake --build build/xcode --config Release
 cpack --config build/xcode/CPackConfig.cmake
 ```
 

--- a/docs/QuickStart.md
+++ b/docs/QuickStart.md
@@ -4,6 +4,7 @@ Having all [requirements](README.md#requirements) set, here you can find how to 
 
 ## Table of contents
 
+- [TL;DR](#tldr)
 - [Build](#build)
 - [Execute](#execute)
   - [macOS](#macos)
@@ -11,6 +12,24 @@ Having all [requirements](README.md#requirements) set, here you can find how to 
   - [Linux](#linux)
 - [Distribution](#distribution)
 - [Tests](#tests)
+
+## TL;DR
+
+> [!IMPORTANT]
+> Workflow presets are only available in CMake version 3.25 and up.
+
+The quickest way possible to get an actual distributable from zero is using the available CMake workflows. For Linux and
+Windows:
+
+```shell
+cmake --workflow --preset dist
+```
+
+And for macOS with Xcode:
+
+```shell
+cmake --workflow --preset xcode-dist
+```
 
 ## Build
 
@@ -30,12 +49,14 @@ cmake -GNinja -DCMAKE_BUILD_TYPE=Release -B build/release
 cmake --build build/release
 ```
 
-On macOS Xcode should be used as generator via `-GXCode`. For example creating a release build with XCode.
+On macOS Xcode should be used as generator via `-GXcode`. For example creating a release build with XCode. It is also
+necessary to specify the Apple architecture via `CMAKE_OSX_ARCHITECTURES`, for example for a universal executable using
+the value `x86_64;arm64"`.
 
 ```shell
-# Using Xcode
-cmake -GXcode -DCMAKE_BUILD_TYPE=Release -B build/xcode
-cmake --build build/xcode
+# Using Xcode, create universal executable
+cmake -GXcode -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -B build/xcode
+cmake --build build/xcode --config Release
 ```
 
 ## Execute

--- a/src/app/cmake/packaging/Linux.cmake
+++ b/src/app/cmake/packaging/Linux.cmake
@@ -23,10 +23,10 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/src/assets/ DESTINATION ${CMAKE_INSTALL_
 # Linux app icon setup
 configure_file(
   ${PROJECT_SOURCE_DIR}/src/app/Manifests/App.desktop.in
-  ${CMAKE_CURRENT_BINARY_DIR}/App.desktop
+  ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.desktop
   @ONLY)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/App.desktop
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.desktop
   DESTINATION share/applications)
 install(FILES ${PROJECT_SOURCE_DIR}/src/assets/icons/BaseAppIcon.png
   DESTINATION share/pixmaps
-  RENAME ${APP_NAME}_icon.png)
+  RENAME ${NAME}_icon.png)


### PR DESCRIPTION
## Description

This PR solves issues building on macOS by defining `CMAKE_OSX_ARCHITECTURES` as cache variable and making it explicit when using the configure command. Also updates docs and preset with new usage. And fixes app icon on Linux.

Driver: https://github.com/MartinHelmut/cpp-gui-template-sdl2/pull/25

## Testing

- [x] macOS
- [x] Linux
- [x] Windows