### PR TITLE
Use templated $NAME

### DIFF
--- a/src/app/cmake/packaging/Darwin.cmake
+++ b/src/app/cmake/packaging/Darwin.cmake
@@ -10,11 +10,11 @@ endif ()
 add_custom_command(TARGET ${NAME} POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy_if_different
   $<TARGET_FILE:SDL2::SDL2>
-  $<TARGET_FILE_DIR:App>/../Frameworks/$<TARGET_FILE_NAME:SDL2::SDL2>)
+  $<TARGET_FILE_DIR:${NAME}>/../Frameworks/$<TARGET_FILE_NAME:SDL2::SDL2>)
 
 # For distribution without XCode:
 if (NOT "${CMAKE_GENERATOR}" STREQUAL "Xcode")
-  install(FILES $<TARGET_FILE:SDL2::SDL2> DESTINATION $<TARGET_FILE_DIR:App>/../Frameworks/)
+  install(FILES $<TARGET_FILE:SDL2::SDL2> DESTINATION $<TARGET_FILE_DIR:${NAME}>/../Frameworks/)
 endif ()
 
 # macOS package settings


### PR DESCRIPTION
Use templated `${NAME}` instead of hardcoded name "App" when building on osx.

This enables cmake --build to pass when using custom application name eg `set(NAME "MyCustomApp")`

And thanks for nice template!